### PR TITLE
Warmwasserboiler mithilfe von Solarstrom einschalten

### DIFF
--- a/fhem/fhem.cfg
+++ b/fhem/fhem.cfg
@@ -347,6 +347,10 @@ setuuid wochenplan 61cb9e6d-f33f-26d3-910b-ec571ffa19ac7216
 attr wochenplan commandTemplate set $NAME  $EVENT
 attr wochenplan room Shelly Dummy
 
+#Warmwasserboiler mithilfe von Solarstrom einschalten
+define warmwasserboilerWattmodus at +*00:00:05 { if (ReadingsVal("Solarstrom","relay_0_power",0) > Value("wattnumberWarmwasserboiler")) { fhem("set Warmwasserboiler on")} else { fhem("set Warmwasserboiler off")}}
+setuuid warmwasserboilerWattmodus 61dc9fd2-f33f-26d3-4156-ec82b75ce28cf910
+
 define myProPlanta PROPLANTA Stuttgart de
 setuuid myProPlanta 61cedee7-f33f-5845-15fe-889b039ec6197f29
 


### PR DESCRIPTION
Hiermit wird noch der Warmwasserboiler mithilfe des Solarstrom gesteuert... Wenn dann alles steht, würde ich das alles verknüpfen :) 